### PR TITLE
feat: add an RSS feed to the Blog

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -37,3 +37,21 @@ module:
   hugoVersion:
     extended: true
     min: "0.110.0"
+
+outputs:
+  home:
+  - html
+  page:
+  - html
+  section:
+  - html
+  - rss
+  taxonomy:
+  - html
+  term:
+  - html
+
+services:
+  rss:
+    limit: 20
+

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,6 +7,10 @@
     <a href="/code_of_conduct" class="hover:underline hover:text-black-600">Code de conduite</a>
     <div>|</div>
     <a href="/posts" class="hover:underline hover:text-black-600">Blog</a>
+    {{ with .OutputFormats.Get "rss" -}}
+      <div>|</div>
+      {{ printf `<a href=%q class="hover:underline hover:text-black-600">Flux RSS</a>` .Permalink | safeHTML }}
+    {{ end }}
   </div>
   <div class="font-normal text-sm">
     Copyright(c) 2024 - Staff42

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -58,3 +58,8 @@
 {{ $styles := $styles | minify | fingerprint | resources.PostProcess }}
 <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}" />
 {{ end }}
+
+{{ with .OutputFormats.Get "rss" -}}
+  {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+{{ end }}
+


### PR DESCRIPTION
- Enable the RSS feed generation in the main configuration
- Add an RSS `link` reference to the `head` element
- Add a "Flux RSS" item to the Blog's footer menu